### PR TITLE
Run surface formatter 0.3.0

### DIFF
--- a/lib/surface_site_web/components/button.ex
+++ b/lib/surface_site_web/components/button.ex
@@ -7,7 +7,7 @@ defmodule SurfaceSiteWeb.Components.Button do
   def render(assigns) do
     ~H"""
     <button class="button {{ @kind }}" :on-click={{ @click }} style="margin: 0px 5px">
-      <slot/>
+      <slot />
     </button>
     """
   end

--- a/lib/surface_site_web/components/card_with_icon.ex
+++ b/lib/surface_site_web/components/card_with_icon.ex
@@ -10,14 +10,14 @@ defmodule SurfaceSiteWeb.Components.CardWithIcon do
       <div class="card-image has-text-centered">
         <div class="container">
           <span class="icon is-large has-text-info" style="margin-top: 40px;margin-bottom: 12px;">
-            <i class="fas {{ @icon }}" style="font-size: 5em;"></i>
+            <i class="fas {{ @icon }}" style="font-size: 5em;" />
           </span>
         </div>
       </div>
       <div class="card-content">
         <div class="content">
           <h4 class="has-text-centered">{{ @title }}</h4>
-          <slot/>
+          <slot />
         </div>
       </div>
     </div>

--- a/lib/surface_site_web/components/component_api.ex
+++ b/lib/surface_site_web/components/component_api.ex
@@ -68,7 +68,7 @@ defmodule SurfaceSiteWeb.Components.ComponentAPI do
               <code>{{ slot.name }}</code>
             </Column>
             <Column label="Description">
-            {{ format_required(slot) }} {{ slot.doc |> format_desc() |> Markdown.to_html(strip: true) }}
+              {{ format_required(slot) }} {{ slot.doc |> format_desc() |> Markdown.to_html(strip: true) }}
             </Column>
           </Table>
         </TabItem>

--- a/lib/surface_site_web/components/component_info.ex
+++ b/lib/surface_site_web/components/component_info.ex
@@ -39,17 +39,17 @@ defmodule SurfaceSiteWeb.Components.ComponentInfo do
       <h1 class="title">{{ @title || full_module_name }}</h1>
       {{ String.trim_trailing(module_summary || "", ".") |> Markdown.to_html(class: "subtitle") }}
       <hr>
-      <div :if={{@examplesPosition == :before_docs}}>
-        <slot name="examples"/>
+      <div :if={{ @examplesPosition == :before_docs }}>
+        <slot name="examples" />
       </div>
       {{ module_doc |> Markdown.to_html() }}
-      <div :if={{@examplesPosition == :after_docs}}>
+      <div :if={{ @examplesPosition == :after_docs }}>
         <hr :if={{ module_doc not in [nil, ""] }}>
-        <slot name="examples"/>
+        <slot name="examples" />
       </div>
       <hr :if={{ assigns[:examples] }}>
-      <SectionSeparator title="Public API" id="{{module_name}}-API"/>
-      <ComponentAPI module={{ @module }}/>
+      <SectionSeparator title="Public API" id="{{ module_name }}-API" />
+      <ComponentAPI module={{ @module }} />
     </div>
     """
   end

--- a/lib/surface_site_web/components/hero.ex
+++ b/lib/surface_site_web/components/hero.ex
@@ -5,7 +5,7 @@ defmodule SurfaceSiteWeb.Components.Hero do
     ~H"""
     <section class="hero is-info">
       <div class="hero-body" style="padding: 2.5rem 1.5rem">
-        <slot/>
+        <slot />
       </div>
     </section>
     """

--- a/lib/surface_site_web/components/section_separator.ex
+++ b/lib/surface_site_web/components/section_separator.ex
@@ -6,8 +6,8 @@ defmodule SurfaceSiteWeb.Components.SectionSeparator do
 
   def render(assigns) do
     ~H"""
-    <h3 id={{@id}} class="title is-4 is-spaced">
-      <a href={{"##{@id}"}}>#</a> {{ @title }}
+    <h3 id={{ @id }} class="title is-4 is-spaced">
+      <a href={{ "##{@id}" }}>#</a> {{ @title }}
     </h3>
     """
   end

--- a/lib/surface_site_web/live/app.ex
+++ b/lib/surface_site_web/live/app.ex
@@ -8,7 +8,7 @@ defmodule SurfaceSiteWeb.App do
   def render(assigns) do
     ~H"""
     <section class="section" style="padding: 3rem 1.5rem">
-      <MobileSidebar/>
+      <MobileSidebar />
       <div class="container">
         <div class="section" style="padding: 0rem 1.5rem">
           <div class="container">

--- a/lib/surface_site_web/live/builtin_components.ex
+++ b/lib/surface_site_web/live/builtin_components.ex
@@ -15,8 +15,8 @@ defmodule SurfaceSiteWeb.BuiltinComponents do
   def render(assigns) do
     ~H"""
     <div style="position: relative;">
-      <MobileSidebar/>
-      <div class="sidebar-bg"/>
+      <MobileSidebar />
+      <div class="sidebar-bg" />
       <div class="container is-fullhd">
         <section class="main-content columns">
           <Sidebar />
@@ -92,217 +92,217 @@ defmodule SurfaceSiteWeb.BuiltinComponents do
 
   defp route(%{component: nil} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.Index id="index"/>
+    <SurfaceSiteWeb.BuiltinComponents.Index id="index" />
     """
   end
 
   defp route(%{component: "InputControls"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.InputControls id="InputControlsInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.InputControls id="InputControlsInfo" />
     """
   end
 
   defp route(%{component: "ColorInput"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.InputControls.ColorInputInfo id="ColorInputInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.InputControls.ColorInputInfo id="ColorInputInfo" />
     """
   end
 
   defp route(%{component: "DateInput"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.InputControls.DateInputInfo id="DateInputInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.InputControls.DateInputInfo id="DateInputInfo" />
     """
   end
 
   defp route(%{component: "DateTimeLocalInput"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.InputControls.DateTimeLocalInputInfo id="DateTimeLocalInputInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.InputControls.DateTimeLocalInputInfo id="DateTimeLocalInputInfo" />
     """
   end
 
   defp route(%{component: "EmailInput"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.EmailInput }}/>
+    <ComponentInfo module={{ Surface.Components.Form.EmailInput }} />
     """
   end
 
   defp route(%{component: "HiddenInput"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.HiddenInput }}/>
+    <ComponentInfo module={{ Surface.Components.Form.HiddenInput }} />
     """
   end
 
   defp route(%{component: "NumberInput"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.NumberInput }}/>
+    <ComponentInfo module={{ Surface.Components.Form.NumberInput }} />
     """
   end
 
   defp route(%{component: "PasswordInput"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.PasswordInput }}/>
+    <ComponentInfo module={{ Surface.Components.Form.PasswordInput }} />
     """
   end
 
   defp route(%{component: "RangeInput"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.InputControls.RangeInputInfo id="RangeInputInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.InputControls.RangeInputInfo id="RangeInputInfo" />
     """
   end
 
   defp route(%{component: "SearchInput"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.SearchInput }}/>
+    <ComponentInfo module={{ Surface.Components.Form.SearchInput }} />
     """
   end
 
   defp route(%{component: "TelephoneInput"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.TelephoneInput }}/>
+    <ComponentInfo module={{ Surface.Components.Form.TelephoneInput }} />
     """
   end
 
   defp route(%{component: "TextInput"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.InputControls.TextInputInfo id="TextInputInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.InputControls.TextInputInfo id="TextInputInfo" />
     """
   end
 
   defp route(%{component: "RadioButton"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.InputControls.RadioButtonInfo id="RadioButtonInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.InputControls.RadioButtonInfo id="RadioButtonInfo" />
     """
   end
 
   defp route(%{component: "TimeInput"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.TimeInput }}/>
+    <ComponentInfo module={{ Surface.Components.Form.TimeInput }} />
     """
   end
 
   defp route(%{component: "UrlInput"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.UrlInput }}/>
+    <ComponentInfo module={{ Surface.Components.Form.UrlInput }} />
     """
   end
 
   defp route(%{component: "Checkbox"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.Checkbox }}/>
+    <ComponentInfo module={{ Surface.Components.Form.Checkbox }} />
     """
   end
 
   defp route(%{component: "Select"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.SelectInfo id="SelectInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.SelectInfo id="SelectInfo" />
     """
   end
 
   defp route(%{component: "Inputs"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.Inputs }}/>
+    <ComponentInfo module={{ Surface.Components.Form.Inputs }} />
     """
   end
 
   defp route(%{component: "FileInput"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.FileInput }}/>
+    <ComponentInfo module={{ Surface.Components.Form.FileInput }} />
     """
   end
 
   defp route(%{component: "HiddenInputs"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.HiddenInputs }}/>
+    <ComponentInfo module={{ Surface.Components.Form.HiddenInputs }} />
     """
   end
 
   defp route(%{component: "MultipleSelect"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.MultipleSelect }}/>
+    <ComponentInfo module={{ Surface.Components.Form.MultipleSelect }} />
     """
   end
 
   defp route(%{component: "OptionsForSelect"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.OptionsForSelect }}/>
+    <ComponentInfo module={{ Surface.Components.Form.OptionsForSelect }} />
     """
   end
 
   defp route(%{component: "TimeSelect"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.TimeSelect }}/>
+    <ComponentInfo module={{ Surface.Components.Form.TimeSelect }} />
     """
   end
 
   defp route(%{component: "DateTimeSelect"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.DateTimeSelect }}/>
+    <ComponentInfo module={{ Surface.Components.Form.DateTimeSelect }} />
     """
   end
 
   defp route(%{component: "Link"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.LinkInfo id="LinkInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.LinkInfo id="LinkInfo" />
     """
   end
 
   defp route(%{component: "LiveRedirect"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.LiveRedirectInfo id="LiveRedirectInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.LiveRedirectInfo id="LiveRedirectInfo" />
     """
   end
 
   defp route(%{component: "LivePatch"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.LivePatchInfo id="LivePatchInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.LivePatchInfo id="LivePatchInfo" />
     """
   end
 
   defp route(%{component: "Form"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.FormInfo id="FormInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.FormInfo id="FormInfo" />
     """
   end
 
   defp route(%{component: "Field"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.FieldInfo id="FieldInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.FieldInfo id="FieldInfo" />
     """
   end
 
   defp route(%{component: "FieldContext"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.FieldContext }}/>
+    <ComponentInfo module={{ Surface.Components.Form.FieldContext }} />
     """
   end
 
   defp route(%{component: "Label"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.LabelInfo id="LabelInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.LabelInfo id="LabelInfo" />
     """
   end
 
   defp route(%{component: "TextArea"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.TextAreaInfo id="TextAreaInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.TextAreaInfo id="TextAreaInfo" />
     """
   end
 
   defp route(%{component: "ErrorTag"} = assigns) do
     ~H"""
-    <ComponentInfo module={{ Surface.Components.Form.ErrorTag }}/>
+    <ComponentInfo module={{ Surface.Components.Form.ErrorTag }} />
     """
   end
 
   defp route(%{component: "Markdown"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.MarkdownInfo id="MarkdownInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.MarkdownInfo id="MarkdownInfo" />
     """
   end
 
   defp route(%{component: "Raw"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BuiltinComponents.RawInfo id="RawInfo"/>
+    <SurfaceSiteWeb.BuiltinComponents.RawInfo id="RawInfo" />
     """
   end
 

--- a/lib/surface_site_web/live/builtin_components/live_redirect_info.ex
+++ b/lib/surface_site_web/live/builtin_components/live_redirect_info.ex
@@ -15,7 +15,7 @@ defmodule SurfaceSiteWeb.BuiltinComponents.LiveRedirectInfo do
               My link
             </LiveRedirect>
           </#Example>
-          <SectionSeparator title="Label" id="label"/>
+          <SectionSeparator title="Label" id="label" />
           <#Example>
             <LiveRedirect label="My link" to="#"/>
           </#Example>

--- a/lib/surface_site_web/live/bulma_components.ex
+++ b/lib/surface_site_web/live/bulma_components.ex
@@ -14,8 +14,8 @@ defmodule SurfaceSiteWeb.BulmaComponents do
   def render(assigns) do
     ~H"""
     <div style="position: relative;">
-      <MobileSidebar/>
-      <div class="sidebar-bg"/>
+      <MobileSidebar />
+      <div class="sidebar-bg" />
       <div class="container is-fullhd">
         <section class="main-content columns">
           <Sidebar />
@@ -48,25 +48,25 @@ defmodule SurfaceSiteWeb.BulmaComponents do
 
   defp route(%{component: nil} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BulmaComponents.Index id="index"/>
+    <SurfaceSiteWeb.BulmaComponents.Index id="index" />
     """
   end
 
   defp route(%{component: "Button"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BulmaComponents.ButtonInfo id="ButtonInfo"/>
+    <SurfaceSiteWeb.BulmaComponents.ButtonInfo id="ButtonInfo" />
     """
   end
 
   defp route(%{component: "Table"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BulmaComponents.TableInfo id="TableInfo"/>
+    <SurfaceSiteWeb.BulmaComponents.TableInfo id="TableInfo" />
     """
   end
 
   defp route(%{component: "Tabs"} = assigns) do
     ~H"""
-    <SurfaceSiteWeb.BulmaComponents.TabsInfo id="TabsInfo"/>
+    <SurfaceSiteWeb.BulmaComponents.TabsInfo id="TabsInfo" />
     """
   end
 

--- a/lib/surface_site_web/live/bulma_components/surface_bulma/button_info.ex
+++ b/lib/surface_site_web/live/bulma_components/surface_bulma/button_info.ex
@@ -69,7 +69,7 @@ defmodule SurfaceSiteWeb.BulmaComponents.ButtonInfo do
         </div>
       </#Example>
 
-      <ComponentAPI module={{ Button }}/>
+      <ComponentAPI module={{ Button }} />
     </div>
     """
   end

--- a/lib/surface_site_web/live/bulma_components/surface_bulma/table_info.ex
+++ b/lib/surface_site_web/live/bulma_components/surface_bulma/table_info.ex
@@ -40,7 +40,7 @@ defmodule SurfaceSiteWeb.BulmaComponents.TableInfo do
         </template>
       </ComponentInfo>
       <br><hr>
-      <ComponentInfo module={{ Column }} title="Table.Column"/>
+      <ComponentInfo module={{ Column }} title="Table.Column" />
     </div>
     """
   end

--- a/lib/surface_site_web/live/bulma_components/surface_bulma/tabs_info.ex
+++ b/lib/surface_site_web/live/bulma_components/surface_bulma/tabs_info.ex
@@ -47,7 +47,7 @@ defmodule SurfaceSiteWeb.BulmaComponents.TabsInfo do
         </template>
       </ComponentInfo>
       <br><hr>
-      <ComponentInfo module={{ TabItem }} title="Tabs.TabItem"/>
+      <ComponentInfo module={{ TabItem }} title="Tabs.TabItem" />
     </div>
     """
   end

--- a/lib/surface_site_web/live/components_basics.ex
+++ b/lib/surface_site_web/live/components_basics.ex
@@ -9,14 +9,13 @@ defmodule SurfaceSiteWeb.ComponentsBasics do
   def render(assigns) do
     ~H"""
     <div style="position: relative;">
-      <MobileSidebar/>
-      <div class="sidebar-bg"/>
+      <MobileSidebar />
+      <div class="sidebar-bg" />
       <div class="container is-fullhd">
         <section class="main-content columns">
           <Sidebar />
           <div class="container column" style="background-color: #fff;">
             <div class="section" style="padding-bottom: 0px;">
-
               <nav class="breadcrumb" aria-label="breadcrumbs">
                 <ul>
                   <li><LiveRedirect label="Home" to="/" /></li>
@@ -138,7 +137,7 @@ defmodule SurfaceSiteWeb.ComponentsBasics do
                 individual tab as follows:
               </#Markdown>
 
-              <ComponentAPI module={{SurfaceSiteWeb.ComponentsBasics.Example02.Button}}/>
+              <ComponentAPI module={{ SurfaceSiteWeb.ComponentsBasics.Example02.Button }} />
 
               <#Markdown>
                 ### Public vs private

--- a/lib/surface_site_web/live/contexts.ex
+++ b/lib/surface_site_web/live/contexts.ex
@@ -8,8 +8,8 @@ defmodule SurfaceSiteWeb.Contexts do
   def render(assigns) do
     ~H"""
     <div style="position: relative;">
-      <MobileSidebar/>
-      <div class="sidebar-bg"/>
+      <MobileSidebar />
+      <div class="sidebar-bg" />
       <div class="container is-fullhd">
         <section class="main-content columns">
           <Sidebar />
@@ -141,7 +141,6 @@ defmodule SurfaceSiteWeb.Contexts do
                 it's highly recommended that you **always** scope those values as demonstrated. This way
                 you make sure it can play nicely with other libraries that also use contexts.
               </#Markdown>
-
             </div>
             <nav class="nav-prev-next">
               <LiveRedirect to="/state_management">

--- a/lib/surface_site_web/live/contexts/example01.ex
+++ b/lib/surface_site_web/live/contexts/example01.ex
@@ -113,12 +113,14 @@ defmodule SurfaceSiteWeb.Contexts.Example01 do
 
     def render(assigns) do
       ~H"""
-      {{ form = form_for(@for, "#",
-         phx_change: assigns.change.name,
-         autocomplete: assigns.autocomplete) }}
-        <Context put={{ form: form }}>
-          <slot/>
-        </Context>
+      {{ form =
+        form_for(@for, "#",
+          phx_change: assigns.change.name,
+          autocomplete: assigns.autocomplete
+        ) }}
+      <Context put={{ form: form }}>
+        <slot />
+      </Context>
       <#Raw></form></#Raw>
       """
     end
@@ -136,12 +138,12 @@ defmodule SurfaceSiteWeb.Contexts.Example01 do
       ~H"""
       <div class="field">
         <Context get={{ form: form }}>
-          {{ label form, @name, class: "label" }}
+          {{ label(form, @name, class: "label") }}
           <div class="control">
             <Context put={{ field: String.to_atom(@name) }}>
-              <slot/>
+              <slot />
             </Context>
-            {{ error_tag form, @name }}
+            {{ error_tag(form, @name) }}
           </div>
         </Context>
       </div>
@@ -191,15 +193,15 @@ defmodule SurfaceSiteWeb.Contexts.Example01 do
         <div class="column">
           <Form for={{ @changeset }} change="validate" autocomplete="off">
             <Field name="name">
-              <TextInput/>
+              <TextInput />
             </Field>
             <Field name="email">
-              <TextInput placeholder="Try me!"/>
+              <TextInput placeholder="Try me!" />
             </Field>
           </Form>
         </div>
         <div class="column">
-      <pre style="height: 170px; border-radius: 6px; padding: 2.25rem">
+          <pre style="height: 170px; border-radius: 6px; padding: 2.25rem">
       {{ @data }}
       </pre>
         </div>

--- a/lib/surface_site_web/live/data.ex
+++ b/lib/surface_site_web/live/data.ex
@@ -8,8 +8,8 @@ defmodule SurfaceSiteWeb.Data do
   def render(assigns) do
     ~H"""
     <div style="position: relative;">
-      <MobileSidebar/>
-      <div class="sidebar-bg"/>
+      <MobileSidebar />
+      <div class="sidebar-bg" />
       <div class="container is-fullhd">
         <section class="main-content columns">
           <Sidebar />
@@ -53,7 +53,7 @@ defmodule SurfaceSiteWeb.Data do
 
               <div class="card dark">
                 <div class="card-content">
-                  <SurfaceSiteWeb.Data.Example01.Counter id="example01"/>
+                  <SurfaceSiteWeb.Data.Example01.Counter id="example01" />
                 </div>
                 <footer class="card-footer">
                   <#Raw>

--- a/lib/surface_site_web/live/data/example01.ex
+++ b/lib/surface_site_web/live/data/example01.ex
@@ -11,8 +11,12 @@ defmodule SurfaceSiteWeb.Data.Example01 do
           {{ @count }}
         </h1>
         <div>
-          <button class="button is-info" :on-click="dec"> - </button>
-          <button class="button is-info" :on-click="inc"> + </button>
+          <button class="button is-info" :on-click="dec">
+            -
+          </button>
+          <button class="button is-info" :on-click="inc">
+            +
+          </button>
         </div>
       </div>
       """

--- a/lib/surface_site_web/live/documentation.ex
+++ b/lib/surface_site_web/live/documentation.ex
@@ -8,10 +8,13 @@ defmodule SurfaceSiteWeb.Documentation do
   def render(assigns) do
     ~H"""
     <div style="position: relative;">
-      <MobileSidebar/>
-      <div class="sidebar-bg"/>
+      <MobileSidebar />
+      <div class="sidebar-bg" />
       <div class="container is-fullhd">
-        <section class="main-content columns" style="margin-top: 0px; margin-bottom: 0px; position: relative;">
+        <section
+          class="main-content columns"
+          style="margin-top: 0px; margin-bottom: 0px; position: relative;"
+        >
           <Sidebar />
           <div class="container column" style="background-color: #fff;">
             <div class="section" style="padding-bottom: 0px;">

--- a/lib/surface_site_web/live/events.ex
+++ b/lib/surface_site_web/live/events.ex
@@ -8,8 +8,8 @@ defmodule SurfaceSiteWeb.Events do
   def render(assigns) do
     ~H"""
     <div style="position: relative;">
-      <MobileSidebar/>
-      <div class="sidebar-bg"/>
+      <MobileSidebar />
+      <div class="sidebar-bg" />
       <div class="container is-fullhd">
         <section class="main-content columns">
           <Sidebar />
@@ -111,7 +111,7 @@ defmodule SurfaceSiteWeb.Events do
 
               <div class="card dark">
                 <div class="card-content">
-                  <SurfaceSiteWeb.Events.SurfaceCounter.Counter id="surface_counter"/>
+                  <SurfaceSiteWeb.Events.SurfaceCounter.Counter id="surface_counter" />
                 </div>
                 <footer class="card-footer">
                   <#Raw>

--- a/lib/surface_site_web/live/getting_started.ex
+++ b/lib/surface_site_web/live/getting_started.ex
@@ -8,8 +8,8 @@ defmodule SurfaceSiteWeb.GettingStarted do
   def render(assigns) do
     ~H"""
     <div style="position: relative;">
-      <MobileSidebar/>
-      <div class="sidebar-bg"/>
+      <MobileSidebar />
+      <div class="sidebar-bg" />
       <div class="container is-fullhd">
         <section class="main-content columns">
           <Sidebar />

--- a/lib/surface_site_web/live/mobile_sidebar.ex
+++ b/lib/surface_site_web/live/mobile_sidebar.ex
@@ -6,7 +6,7 @@ defmodule SurfaceSiteWeb.MobileSidebar do
   def render(assigns) do
     ~H"""
     <div id="mobile-sidebar" class="mobile-sidebar" phx-hook="MobileSidebar">
-      <div class="sidebar-background" onclick="closeMobileSidebar()" style="display: none;"></div>
+      <div class="sidebar-background" onclick="closeMobileSidebar()" style="display: none;" />
       <div class="sidebar-content is-fixed is-fullheight animated faster" style="display: none;">
         <section class="hero is-info">
           <div class="hero-body" style="padding: 2.3rem 1.5rem 2.5rem 1.5rem">
@@ -20,7 +20,7 @@ defmodule SurfaceSiteWeb.MobileSidebar do
             </div>
           </div>
         </section>
-        <SidebarMenu/>
+        <SidebarMenu />
       </div>
     </div>
     """

--- a/lib/surface_site_web/live/properties.ex
+++ b/lib/surface_site_web/live/properties.ex
@@ -8,8 +8,8 @@ defmodule SurfaceSiteWeb.Properties do
   def render(assigns) do
     ~H"""
     <div style="position: relative;">
-      <MobileSidebar/>
-      <div class="sidebar-bg"/>
+      <MobileSidebar />
+      <div class="sidebar-bg" />
       <div class="container is-fullhd">
         <section class="main-content columns">
           <Sidebar />

--- a/lib/surface_site_web/live/properties/example01.ex
+++ b/lib/surface_site_web/live/properties/example01.ex
@@ -21,7 +21,7 @@ defmodule SurfaceSiteWeb.Properties.Example01 do
 
     def render(assigns) do
       ~H"""
-      <Hello name="John Doe"/>
+      <Hello name="John Doe" />
       """
     end
   end

--- a/lib/surface_site_web/live/properties/example02.ex
+++ b/lib/surface_site_web/live/properties/example02.ex
@@ -8,7 +8,7 @@ defmodule SurfaceSiteWeb.Properties.Example02 do
     def render(assigns) do
       ~H"""
       <button class={{ "button", "is-info", "is-loading": @loading, "is-rounded": @rounded }}>
-        <slot/>
+        <slot />
       </button>
       """
     end

--- a/lib/surface_site_web/live/sidebar.ex
+++ b/lib/surface_site_web/live/sidebar.ex
@@ -9,7 +9,7 @@ defmodule SurfaceSiteWeb.Sidebar do
       class="section column is-narrow is-narrow-mobile is-fullheight is-hidden-mobile"
       style="background-color: #f5f5f5;"
     >
-      <SidebarMenu/>
+      <SidebarMenu />
     </aside>
     """
   end

--- a/lib/surface_site_web/live/sidebar_menu.ex
+++ b/lib/surface_site_web/live/sidebar_menu.ex
@@ -9,71 +9,93 @@ defmodule SurfaceSiteWeb.SidebarMenu do
       <li>
         <LiveRedirect to="/">
           <span class="icon">
-            <i class="fa fa-home"></i>
-          </span> Home
+            <i class="fa fa-home" />
+          </span>
+          Home
         </LiveRedirect>
       </li>
       <li>
-        <LiveRedirect class="" to= "/getting_started">
+        <LiveRedirect class="" to="/getting_started">
           <span class="icon">
-            <i class="fa fa-power-off"></i>
-          </span> Getting started
+            <i class="fa fa-power-off" />
+          </span>
+          Getting started
         </LiveRedirect>
       </li>
       <li>
         <LiveRedirect class="" to="/documentation">
           <span class="icon">
-            <i class="fa fa-book"></i>
-          </span> Documentation
+            <i class="fa fa-book" />
+          </span>
+          Documentation
         </LiveRedirect>
         <ul>
           <li>
             <LiveRedirect class="" to="/components_basics">
               <span class="icon">
-                <i class="far fa-file-code"></i>
-              </span> Components Basics
+                <i class="far fa-file-code" />
+              </span>
+              Components Basics
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/properties">
               <span class="icon">
-                <i class="fa fa-cubes"></i>
-              </span> Properties
+                <i class="fa fa-cubes" />
+              </span>
+              Properties
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/data">
               <span class="icon">
-                <i class="fa fa-cube"></i>
-              </span> Data
+                <i class="fa fa-cube" />
+              </span>
+              Data
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/events">
               <span class="icon">
-                <i class="fa fa-bolt"></i>
-              </span> Events
+                <i class="fa fa-bolt" />
+              </span>
+              Events
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/slots">
               <span class="icon">
-              <svg class="svg-inline--fa fa-align-left fa-w-14" aria-hidden="true" data-prefix="fas" data-icon="align-left" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M288 44v40c0 8.837-7.163 16-16 16H16c-8.837 0-16-7.163-16-16V44c0-8.837 7.163-16 16-16h256c8.837 0 16 7.163 16 16zM0 172v40c0 8.837 7.163 16 16 16h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16zm16 312h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm256-200H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16h256c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16z"></path></svg>
-              </span> Slots
+                <svg
+                  class="svg-inline--fa fa-align-left fa-w-14"
+                  aria-hidden="true"
+                  data-prefix="fas"
+                  data-icon="align-left"
+                  role="img"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 448 512"
+                  data-fa-i2svg=""
+                ><path
+                    fill="currentColor"
+                    d="M288 44v40c0 8.837-7.163 16-16 16H16c-8.837 0-16-7.163-16-16V44c0-8.837 7.163-16 16-16h256c8.837 0 16 7.163 16 16zM0 172v40c0 8.837 7.163 16 16 16h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16zm16 312h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm256-200H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16h256c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16z"
+                  /></svg>
+              </span>
+              Slots
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/state_management">
               <span class="icon">
-                <i class="fa fa-exchange-alt"></i>
-              </span> State Management
+                <i class="fa fa-exchange-alt" />
+              </span>
+              State Management
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/contexts">
               <span class="icon">
-                <i class="fa fa-sitemap"></i>
-              </span> Contexts
+                <i class="fa fa-sitemap" />
+              </span>
+              Contexts
             </LiveRedirect>
           </li>
         </ul>
@@ -81,8 +103,9 @@ defmodule SurfaceSiteWeb.SidebarMenu do
       <li>
         <LiveRedirect class="" to="/builtincomponents">
           <span class="icon">
-            <i class="fa fa-code"></i>
-          </span> Built-in Components
+            <i class="fa fa-code" />
+          </span>
+          Built-in Components
         </LiveRedirect>
         <ul>
           <li>
@@ -91,22 +114,25 @@ defmodule SurfaceSiteWeb.SidebarMenu do
           <li>
             <LiveRedirect class="" to="/builtincomponents/Link">
               <span class="icon is-small">
-                <i class="fas fa-link"></i>
-              </span> Link
+                <i class="fas fa-link" />
+              </span>
+              Link
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/builtincomponents/LivePatch">
               <span class="icon is-small">
-                <i class="fas fa-external-link-square-alt"></i>
-              </span> LivePatch
+                <i class="fas fa-external-link-square-alt" />
+              </span>
+              LivePatch
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/builtincomponents/LiveRedirect">
               <span class="icon is-small">
-                <i class="fa fa-external-link-alt"></i>
-              </span> LiveRedirect
+                <i class="fa fa-external-link-alt" />
+              </span>
+              LiveRedirect
             </LiveRedirect>
           </li>
           <li>
@@ -115,57 +141,65 @@ defmodule SurfaceSiteWeb.SidebarMenu do
           <li>
             <LiveRedirect class="" to="/builtincomponents/Form">
               <span class="icon is-small">
-                <i class="fab fa-wpforms"></i>
-              </span> Form
+                <i class="fab fa-wpforms" />
+              </span>
+              Form
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/builtincomponents/Field">
               <span class="icon is-small">
-                <i class="fas fa-minus"></i>
-              </span> Field
+                <i class="fas fa-minus" />
+              </span>
+              Field
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/builtincomponents/FieldContext">
               <span class="icon is-small">
-                <i class="fas fa-folder-minus"></i>
-              </span> FieldContext
+                <i class="fas fa-folder-minus" />
+              </span>
+              FieldContext
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/builtincomponents/Label">
               <span class="icon is-small">
-                <i class="fas fa-font"></i>
-              </span> Label
+                <i class="fas fa-font" />
+              </span>
+              Label
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/builtincomponents/InputControls">
               <span class="icon is-small">
-                <i class="fa fa-equals"></i>
-              </span> Input Controls
+                <i class="fa fa-equals" />
+              </span>
+              Input Controls
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/builtincomponents/TextArea">
               <span class="icon is-small">
-                <i class="far fa-square"></i>
-              </span> TextArea
+                <i class="far fa-square" />
+              </span>
+              TextArea
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/builtincomponents/Select">
               <span class="icon is-small">
-                <i class="fas fa-mouse-pointer"></i>
-              </span> Select
+                <i class="fas fa-mouse-pointer" />
+              </span>
+              Select
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/builtincomponents/ErrorTag">
               <span class="icon is-small">
-                <i class="fas fa-exclamation"></i>
-              </span> ErrorTag
+                <i class="fas fa-exclamation" />
+              </span>
+              ErrorTag
             </LiveRedirect>
           </li>
           <li>
@@ -174,15 +208,17 @@ defmodule SurfaceSiteWeb.SidebarMenu do
           <li>
             <LiveRedirect class="" to="/builtincomponents/Markdown">
               <span class="icon is-small">
-                <i class="fab fa-markdown"></i>
-              </span> Markdown
+                <i class="fab fa-markdown" />
+              </span>
+              Markdown
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/builtincomponents/Raw">
               <span class="icon is-small">
-                <i class="far fa-file-code"></i>
-              </span> Raw
+                <i class="far fa-file-code" />
+              </span>
+              Raw
             </LiveRedirect>
           </li>
         </ul>
@@ -190,29 +226,33 @@ defmodule SurfaceSiteWeb.SidebarMenu do
       <li>
         <LiveRedirect class="" to="/uicomponents">
           <span class="icon">
-            <i class="fa fa-puzzle-piece"></i>
-          </span> UI Components (WIP)
+            <i class="fa fa-puzzle-piece" />
+          </span>
+          UI Components (WIP)
         </LiveRedirect>
         <ul>
           <li>
             <LiveRedirect class="" to="/uicomponents/Button">
               <span class="icon is-small">
-                <i class="fa fa-hand-pointer"></i>
-              </span> Button
+                <i class="fa fa-hand-pointer" />
+              </span>
+              Button
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/uicomponents/Table">
               <span class="icon is-small">
-                <i class="fa fa-table"></i>
-              </span> Table
+                <i class="fa fa-table" />
+              </span>
+              Table
             </LiveRedirect>
           </li>
           <li>
             <LiveRedirect class="" to="/uicomponents/Tabs">
               <span class="icon is-small">
-                <i class="fa fa-folder"></i>
-              </span> Tabs
+                <i class="fa fa-folder" />
+              </span>
+              Tabs
             </LiveRedirect>
           </li>
         </ul>

--- a/lib/surface_site_web/live/slots.ex
+++ b/lib/surface_site_web/live/slots.ex
@@ -8,11 +8,11 @@ defmodule SurfaceSiteWeb.Slots do
   def render(assigns) do
     ~H"""
     <div style="position: relative;">
-      <MobileSidebar/>
-      <div class="sidebar-bg"/>
+      <MobileSidebar />
+      <div class="sidebar-bg" />
       <div class="container is-fullhd">
         <section class="main-content columns">
-          <Sidebar/>
+          <Sidebar />
           <div class="container column" style="background-color: #fff;">
             <div class="section" style="padding-bottom: 0px;">
               <nav class="breadcrumb" aria-label="breadcrumbs">
@@ -215,7 +215,7 @@ defmodule SurfaceSiteWeb.Slots do
 
               <div class="card dark">
                 <div class="card-content slots-page-props-example">
-                  <SurfaceSiteWeb.Slots.SlotPropsExample.Example id="slot_props_example"/>
+                  <SurfaceSiteWeb.Slots.SlotPropsExample.Example id="slot_props_example" />
                 </div>
                 <footer class="card-footer">
                   <#Raw>
@@ -245,7 +245,7 @@ defmodule SurfaceSiteWeb.Slots do
 
               <div class="card dark">
                 <div class="card-content">
-                  <SurfaceSiteWeb.GettingStarted.RenderlessComponent.Example id="renderless_component"/>
+                  <SurfaceSiteWeb.GettingStarted.RenderlessComponent.Example id="renderless_component" />
                 </div>
                 <footer class="card-footer">
                   <#Raw>

--- a/lib/surface_site_web/live/slots/binding_slots_to_generators.ex
+++ b/lib/surface_site_web/live/slots/binding_slots_to_generators.ex
@@ -28,7 +28,7 @@ defmodule SurfaceSiteWeb.GettingStarted.BindingSlotsToGenerators do
         <tbody>
           <tr :for={{ item <- @items }} class={{ "is-selected": item[:selected] }}>
             <td :for.index={{ @cols }}>
-              <slot name="cols" index={{ index }} :props={{ item: item }}/>
+              <slot name="cols" index={{ index }} :props={{ item: item }} />
             </td>
           </tr>
         </tbody>

--- a/lib/surface_site_web/live/slots/declared_slot_example.ex
+++ b/lib/surface_site_web/live/slots/declared_slot_example.ex
@@ -11,7 +11,7 @@ defmodule SurfaceSiteWeb.Slots.DeclaredSlotExample do
       ~H"""
       <section class="hero is-info">
         <div class="hero-body">
-          <slot/>
+          <slot />
         </div>
       </section>
       """

--- a/lib/surface_site_web/live/slots/named_slots_example.ex
+++ b/lib/surface_site_web/live/slots/named_slots_example.ex
@@ -18,16 +18,16 @@ defmodule SurfaceSiteWeb.Slots.NamedSlotsExample do
       <div class="card">
         <header class="card-header" style="background-color: #f5f5f5">
           <p class="card-header-title">
-            <slot name="header"/>
+            <slot name="header" />
           </p>
         </header>
         <div class="card-content">
           <div class="content">
-            <slot/>
+            <slot />
           </div>
         </div>
         <footer class="card-footer" style="background-color: #f5f5f5">
-          <slot name="footer"/>
+          <slot name="footer" />
         </footer>
       </div>
       """

--- a/lib/surface_site_web/live/slots/slot_example.ex
+++ b/lib/surface_site_web/live/slots/slot_example.ex
@@ -8,7 +8,7 @@ defmodule SurfaceSiteWeb.Slots.SlotExample do
       ~H"""
       <section class="hero is-info">
         <div class="hero-body">
-          <slot/>
+          <slot />
         </div>
       </section>
       """

--- a/lib/surface_site_web/live/slots/slot_fallback_example.ex
+++ b/lib/surface_site_web/live/slots/slot_fallback_example.ex
@@ -27,7 +27,7 @@ defmodule SurfaceSiteWeb.Slots.SlotFallbackExample do
 
     def render(assigns) do
       ~H"""
-      <Hero></Hero>
+      <Hero />
       """
     end
   end

--- a/lib/surface_site_web/live/slots/slot_props_example.ex
+++ b/lib/surface_site_web/live/slots/slot_props_example.ex
@@ -14,7 +14,7 @@ defmodule SurfaceSiteWeb.Slots.SlotPropsExample do
       ~H"""
       <div>
         <p>
-          <slot :props={{ value: @value, max: @max }}/>
+          <slot :props={{ value: @value, max: @max }} />
         </p>
         <div style="padding-top: 10px;">
           <button class="button is-info" :on-click="dec" disabled={{ @value == 1 }}>
@@ -54,7 +54,7 @@ defmodule SurfaceSiteWeb.Slots.SlotPropsExample do
         <Rating :let={{ value: value, max: max }} id="rating_2">
           <div>
             <span :for={{ i <- 1..max }} class={{ :icon, "has-text-warning": i <= value }}>
-              <i class="fas fa-star"></i>
+              <i class="fas fa-star" />
             </span>
           </div>
         </Rating>

--- a/lib/surface_site_web/live/slots/typed_slots_example.ex
+++ b/lib/surface_site_web/live/slots/typed_slots_example.ex
@@ -18,16 +18,16 @@ defmodule SurfaceSiteWeb.Slots.TypedSlotsExample do
       <div class="card">
         <header class="card-header" style="background-color: #f5f5f5">
           <p class="card-header-title">
-            <slot name="header"/>
+            <slot name="header" />
           </p>
         </header>
         <div class="card-content">
           <div class="content">
-            <slot/>
+            <slot />
           </div>
         </div>
         <footer class="card-footer" style="background-color: #f5f5f5">
-          <slot name="footer"/>
+          <slot name="footer" />
         </footer>
       </div>
       """

--- a/lib/surface_site_web/live/state_management.ex
+++ b/lib/surface_site_web/live/state_management.ex
@@ -8,8 +8,8 @@ defmodule SurfaceSiteWeb.StateManagement do
   def render(assigns) do
     ~H"""
     <div style="position: relative;">
-      <MobileSidebar/>
-      <div class="sidebar-bg"/>
+      <MobileSidebar />
+      <div class="sidebar-bg" />
       <div class="container is-fullhd">
         <section class="main-content columns">
           <Sidebar />
@@ -77,7 +77,7 @@ defmodule SurfaceSiteWeb.StateManagement do
 
               <div class="card dark">
                 <div class="card-content">
-                  <SurfaceSiteWeb.StateManagement.Example01.Example id="example_01"/>
+                  <SurfaceSiteWeb.StateManagement.Example01.Example id="example_01" />
                 </div>
                 <footer class="card-footer">
                   <#Raw>
@@ -155,7 +155,7 @@ defmodule SurfaceSiteWeb.StateManagement do
 
               <div class="card dark">
                 <div class="card-content">
-                  <SurfaceSiteWeb.StateManagement.Example02.Example id="example_02"/>
+                  <SurfaceSiteWeb.StateManagement.Example02.Example id="example_02" />
                 </div>
                 <footer class="card-footer">
                   <#Raw>

--- a/lib/surface_site_web/live/state_management/example01.ex
+++ b/lib/surface_site_web/live/state_management/example01.ex
@@ -8,7 +8,7 @@ defmodule SurfaceSiteWeb.StateManagement.Example01 do
     def render(assigns) do
       ~H"""
       <button class="button {{ @kind }}" :on-click={{ @click }}>
-        <slot/>
+        <slot />
       </button>
       """
     end
@@ -24,13 +24,13 @@ defmodule SurfaceSiteWeb.StateManagement.Example01 do
     def render(assigns) do
       ~H"""
       <div class={{ "modal", "is-active": @show }}>
-        <div class="modal-background"></div>
+        <div class="modal-background" />
         <div class="modal-card">
           <header class="modal-card-head">
             <p class="modal-card-title">{{ @title }}</p>
           </header>
           <section class="modal-card-body">
-            <slot/>
+            <slot />
           </section>
           <footer class="modal-card-foot" style="justify-content: flex-end">
             <Button click={{ @hideEvent }}>Ok</Button>

--- a/lib/surface_site_web/live/state_management/example02.ex
+++ b/lib/surface_site_web/live/state_management/example02.ex
@@ -8,7 +8,7 @@ defmodule SurfaceSiteWeb.StateManagement.Example02 do
     def render(assigns) do
       ~H"""
       <button class="button {{ @kind }}" :on-click={{ @click }} style="margin: 0px 5px">
-        <slot/>
+        <slot />
       </button>
       """
     end
@@ -24,13 +24,13 @@ defmodule SurfaceSiteWeb.StateManagement.Example02 do
     def render(assigns) do
       ~H"""
       <div class={{ "modal", "is-active": @show }} :on-window-keydown="hide" phx-key="Escape">
-        <div class="modal-background"></div>
+        <div class="modal-background" />
         <div class="modal-card">
           <header class="modal-card-head">
             <p class="modal-card-title">{{ @title }}</p>
           </header>
           <section class="modal-card-body">
-            <slot/>
+            <slot />
           </section>
           <footer class="modal-card-foot" style="justify-content: flex-end">
             <Button click="hide" kind="is-info">Ok</Button>

--- a/lib/surface_site_web/live/state_management/readme_example.ex
+++ b/lib/surface_site_web/live/state_management/readme_example.ex
@@ -10,7 +10,7 @@ defmodule SurfaceSiteWeb.StateManagement.ReadmeExample do
     def render(assigns) do
       ~H"""
       <button class="button {{ @kind }}" phx-click={{ @click }} style="margin: 0px 5px">
-        <slot/>
+        <slot />
       </button>
       """
     end
@@ -32,13 +32,13 @@ defmodule SurfaceSiteWeb.StateManagement.ReadmeExample do
     def render(assigns) do
       ~H"""
       <div class={{ "modal", "is-active": @show }}>
-        <div class="modal-background"></div>
+        <div class="modal-background" />
         <div class="modal-card">
           <header class="modal-card-head">
             <p class="modal-card-title">{{ @title }}</p>
           </header>
           <section class="modal-card-body">
-            <slot/>
+            <slot />
           </section>
           <footer class="modal-card-foot" style="justify-content: flex-end">
             <Button click="hide">Ok</Button>

--- a/lib/surface_site_web/views/layout_view.ex
+++ b/lib/surface_site_web/views/layout_view.ex
@@ -6,16 +6,41 @@ defmodule SurfaceSiteWeb.LayoutView do
     <html lang="en">
       <head>
         {{ Phoenix.HTML.Tag.csrf_meta_tag() }}
-        <meta charset="utf-8"/>
-        <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-        <meta name="viewport" content="initial-scale=1, maximum-scale=1, minimum-scale=1"/>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="initial-scale=1, maximum-scale=1, minimum-scale=1">
         <title>Surface</title>
-        <link phx-track-static rel="stylesheet" href={{ Routes.static_path(@conn, "/css/app.css") }}/>
-        <script defer phx-track-static type="text/javascript" src={{ Routes.static_path(@conn, "/js/app.js") }}></script>
+        <link phx-track-static rel="stylesheet" href={{ Routes.static_path(@conn, "/css/app.css") }}>
+        <script
+          defer
+          phx-track-static
+          type="text/javascript"
+          src={{ Routes.static_path(@conn, "/js/app.js") }}
+        />
       </head>
       <body>
-        <a href="https://github.com/msaraiva/surface" title="Source Code on GitHub" class="github-corner" aria-label="View source on GitHub">
-          <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#fff; color:#209cee; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg>
+        <a
+          href="https://github.com/msaraiva/surface"
+          title="Source Code on GitHub"
+          class="github-corner"
+          aria-label="View source on GitHub"
+        >
+          <svg
+            width="80"
+            height="80"
+            viewBox="0 0 250 250"
+            style="fill:#fff; color:#209cee; position: absolute; top: 0; border: 0; right: 0;"
+            aria-hidden="true"
+          ><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z" /><path
+              d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+              fill="currentColor"
+              style="transform-origin: 130px 106px;"
+              class="octo-arm"
+            /><path
+              d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+              fill="currentColor"
+              class="octo-body"
+            /></svg>
         </a>
         <style>
           .github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
@@ -30,7 +55,7 @@ defmodule SurfaceSiteWeb.LayoutView do
                 A <strong>server-side rendering</strong> component library for <strong>Phoenix</strong>
               </h2>
               <span class="mobile-sidebar-open-button icon is-small" onclick="openMobileSidebar()">
-                <i class="fa fa-bars"></i>
+                <i class="fa fa-bars" />
               </span>
             </div>
           </div>

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,8 @@ defmodule SurfaceSite.MixProject do
       {:ecto_sql, "~> 3.0"},
       {:postgrex, ">= 0.0.0"},
       {:jason, "~> 1.0"},
-      {:surface, "~> 0.1.1"},
+      {:surface, "~> 0.1.1", override: true},
+      {:surface_formatter, "~> 0.3"},
       {:surface_bulma, github: "msaraiva/surface_bulma"},
       {:earmark, "~> 1.3"},
       {:html_entities, "~> 0.4"}

--- a/mix.lock
+++ b/mix.lock
@@ -27,5 +27,6 @@
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm", "451d8527787df716d99dc36162fca05934915db0b6141bbdac2ea8d3c7afc7d7"},
   "surface": {:hex, :surface, "0.1.1", "812249c5832d1b36051101a3fe68eac374758cc4437652bf9bf2cb14ab052fb7", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}, {:phoenix_live_view, "~> 0.15.0", [hex: :phoenix_live_view, repo: "hexpm", optional: false]}], "hexpm", "08b2c00ad1a3c6d0f60fa05bda43aa90b112f71e7989870a6e756670fdc1698c"},
   "surface_bulma": {:git, "https://github.com/msaraiva/surface_bulma.git", "5b32f8fa6e56589a3411756efd30955e04561e89", []},
+  "surface_formatter": {:hex, :surface_formatter, "0.3.0", "07b83e7748167a4e5dce629cb7a87ac10aa29ebb445087fe1d57b32f6ad39390", [:mix], [{:surface, "~> 0.3.0", [hex: :surface, repo: "hexpm", optional: false]}], "hexpm", "092c0d832c2c98219b96b57e84bd5d768a5b00b80938b2de987177542f571524"},
   "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
 }


### PR DESCRIPTION
Replacing https://github.com/surface-ui/surface_site/pull/6. The new `surface_formatter` is now aware of void elements that don't need a trailing slash. It no longer changes `<br><hr>` to `<br /><hr />`.