### PR TITLE
Actually use hooks in the liveSocket in JS example

### DIFF
--- a/lib/surface_site_web/live/js_interop.ex
+++ b/lib/surface_site_web/live/js_interop.ex
@@ -56,6 +56,8 @@ defmodule SurfaceSiteWeb.JSInterop do
 
                 ```js
                 import Hooks from "./_hooks"
+                // ...
+                let liveSocket = new LiveSocket("/live", Socket, { params: { _csrf_token: csrfToken }, hooks: Hooks })
                 ```
 
                 Update the Endpoint options in `config/dev.exs` for live reload of JS hooks:


### PR DESCRIPTION
I thought "automatically load JS hooks" meant I didn't have to assign it to the livesocket either. 