### PR TITLE
Update getting started to the more recent ~> 0.4.1

### DIFF
--- a/lib/surface_site_web/live/getting_started.ex
+++ b/lib/surface_site_web/live/getting_started.ex
@@ -46,7 +46,7 @@ defmodule SurfaceSiteWeb.GettingStarted do
                 ```elixir
                 def deps do
                   [
-                    {:surface, "~> 0.3.0"}
+                    {:surface, "~> 0.4.1"}
                   ]
                 end
                 ```


### PR DESCRIPTION
It seems like the suggested version in the `getting_started` page had gotten a little behind. This pull request updates to 0.4.1. Thanks