### PR TITLE
SurfaceSiteWeb.BuiltinComponents.FieldInfo: pass name attribute as atom

### DIFF
--- a/lib/surface_site_web/live/builtin_components/field_info.ex
+++ b/lib/surface_site_web/live/builtin_components/field_info.ex
@@ -14,7 +14,7 @@ defmodule SurfaceSiteWeb.BuiltinComponents.FieldInfo do
         <template slot="examples">
           <#Example>
             <Form for={{ :user }}>
-              <Field name="email">
+              <Field name={{ :email }}>
                 <Label>E-mail</Label>
                 <div class="control">
                   <TextInput value={{ @user["email"] }}/>


### PR DESCRIPTION
I upgraded from 0.3.0 to 0.4.1 and got an ArgumentError because passing a string to `text_input` from Phoenix.HTML (from inside Surface) resulted in the string being passed to `:erlang.atom_to_binary` inside `Phoenix.HTML.FormData.Ecto.Changeset.input_value/4`.

In my situation I passed a changeset to the surrounding Form tag, and the error might only happen in that situation. However it's probably a good default to pass an atom here in every case.