### PR TITLE
add arguments column on public API slot section

### DIFF
--- a/lib/surface_site_web/components/component_api.ex
+++ b/lib/surface_site_web/components/component_api.ex
@@ -68,6 +68,9 @@ defmodule SurfaceSiteWeb.Components.ComponentAPI do
             <Column label="Description">
               {format_required(slot)} {slot.doc |> format_desc() |> Markdown.to_html(strip: true)}
             </Column>
+            <Column label="Arguments">
+              {format_args(slot.opts_ast)}
+            </Column>
           </Table>
         </TabItem>
         <TabItem label="Events" visible={@events != []}>
@@ -130,6 +133,22 @@ defmodule SurfaceSiteWeb.Components.ComponentAPI do
 
   defp format_value(value) when is_binary(value) do
     inspect(value)
+  end
+
+  defp format_args(opts) when opts in [nil, []] do
+    "—"
+  end
+
+  defp format_args(opts) do
+    if Keyword.has_key?(opts, :args) do
+      opts[:args]
+      |> Enum.map(fn key ->
+        raw(["<code>", inspect(key), "</code>"])
+      end)
+      |> Enum.intersperse(", ")
+    else
+      "—"
+    end
   end
 
   defp format_default(opts) do


### PR DESCRIPTION
- when slots have no arguments should exhibit `--`.
- when slots have one or more arguments should exhibit something like:
  - `:form`
  - `:form`, `:index`

Also, this PR is related to this issue here: https://github.com/surface-ui/surface/issues/583

preview:
<img width="1339" alt="Screen Shot 2022-05-06 at 16 04 37" src="https://user-images.githubusercontent.com/1036970/167202038-505b243b-3120-495d-8937-309689b2b29a.png">

---

<img width="1396" alt="Screen Shot 2022-05-06 at 16 05 25" src="https://user-images.githubusercontent.com/1036970/167202043-e5eb4d3b-921b-4652-95ba-44bc117c6816.png">

---

<img width="1393" alt="Screen Shot 2022-05-06 at 16 05 53" src="https://user-images.githubusercontent.com/1036970/167202045-19d78176-fd1c-4ab4-b4ad-0e898e06fab9.png">
