### PR TITLE
added missing socket or assigns first param

### DIFF
--- a/lib/surface_site_web/live/contexts.ex
+++ b/lib/surface_site_web/live/contexts.ex
@@ -96,7 +96,7 @@ defmodule SurfaceSiteWeb.Contexts do
                 Now, whenever you need to retrieve the value, you must pass the scope too:
 
                 ```elixir
-                form = Context.get(Form, :form)
+                form = Context.get(socket_or_assigns, Form, :form)
                 ```
 
                 ```surface


### PR DESCRIPTION
According to Hexdocs, https://hexdocs.pm/surface/Surface.Components.Context.html#get/3-usage,
`Context.get` should have a first param of socket or assigns.