### PR TITLE
clarify which dependencies are included in scoped CSS (and JS hooks)

### DIFF
--- a/lib/surface_site_web/live/scoped_css.ex
+++ b/lib/surface_site_web/live/scoped_css.ex
@@ -41,7 +41,7 @@ defmodule SurfaceSiteWeb.ScopedCSS do
                     like editor highlighters, linters, etc.
                   * Auto generate Taiwind variants based on `prop`/`data` using the `css_variant` option.
                   * Zero-configuration in `app.css` or any other file when importing new components, including
-                    components from dependencies (tha is, any dependency that has `surface` as a dependency). The compiler  
+                    components from dependencies (that is, any dependency that has `surface` as a dependency). The compiler  
                     will automatically collect and process all component-related styles seamlessly.
 
                 ## Usage with colocated `.css` file

--- a/lib/surface_site_web/live/scoped_css.ex
+++ b/lib/surface_site_web/live/scoped_css.ex
@@ -41,8 +41,8 @@ defmodule SurfaceSiteWeb.ScopedCSS do
                     like editor highlighters, linters, etc.
                   * Auto generate Taiwind variants based on `prop`/`data` using the `css_variant` option.
                   * Zero-configuration in `app.css` or any other file when importing new components, including
-                    components from dependencies. The compiler will automatically collect and process all component-related
-                    styles seamlessly.
+                    components from dependencies (tha is, any dependency that has `surface` as a dependency). The compiler  
+                    will automatically collect and process all component-related styles seamlessly.
 
                 ## Usage with colocated `.css` file
 


### PR DESCRIPTION
I spent some time debugging why some components weren't included, and it turned out the dependencies where they were defined depend on a dependency that in turn depends on surface, and those aren't included in `Surface.components()`